### PR TITLE
fix:zarinpal

### DIFF
--- a/config/larapay.php
+++ b/config/larapay.php
@@ -27,7 +27,8 @@ return [
     | the gateways list is comma separated
     |
     */
-    'gateways' => env('LARAPAY_GATES', 'Mellat,Saman,Pasargad,Parsian,ZarinPal,Idpay,Payir,Saderat,Zibal,Nextpay'),
+    'gateways' => env('LARAPAY_GATES', 
+'Mellat,Saman,Pasargad,Parsian,Zarinpal,Idpay,Payir,Saderat,Zibal,Nextpay'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Adapter/AdapterAbstract.php
+++ b/src/Adapter/AdapterAbstract.php
@@ -4,7 +4,7 @@ namespace Tartan\Larapay\Adapter;
 
 use SoapClient;
 use Tartan\Larapay\Transaction\TransactionInterface;
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 
 /**
  * Class AdapterAbstract

--- a/src/Adapter/Idpay.php
+++ b/src/Adapter/Idpay.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Tartan\Larapay\Adapter;
 
 use Tartan\Larapay\Adapter\Idpay\Exception;
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 
 
 /**

--- a/src/Adapter/Mellat.php
+++ b/src/Adapter/Mellat.php
@@ -5,7 +5,7 @@ namespace Tartan\Larapay\Adapter;
 
 use SoapFault;
 use Tartan\Larapay\Adapter\Mellat\Exception;
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 
 /**
  * Class Mellat

--- a/src/Adapter/Nextpay.php
+++ b/src/Adapter/Nextpay.php
@@ -5,7 +5,7 @@ namespace Tartan\Larapay\Adapter;
 
 use Tartan\Larapay\Adapter\Nextpay\Exception;
 use Tartan\Larapay\Adapter\Nextpay\Helper;
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 
 /**
  * Class Nextpay

--- a/src/Adapter/Nextpay/Helper.php
+++ b/src/Adapter/Nextpay/Helper.php
@@ -1,7 +1,7 @@
 <?php
 namespace Tartan\Larapay\Adapter\Nextpay;
 
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 
 class Helper
 {

--- a/src/Adapter/Parsian.php
+++ b/src/Adapter/Parsian.php
@@ -7,7 +7,7 @@ namespace Tartan\Larapay\Adapter;
 use a\Sharing;
 use SoapFault;
 use Tartan\Larapay\Adapter\Parsian\Exception;
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 
 /**
  * Class Parsian

--- a/src/Adapter/Pasargad.php
+++ b/src/Adapter/Pasargad.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tartan\Larapay\Adapter;
 
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 use Tartan\Larapay\Adapter\Pasargad\Helper;
 use Tartan\Larapay\Adapter\Pasargad\RSAKeyType;
 use Tartan\Larapay\Adapter\Pasargad\RSAProcessor;

--- a/src/Adapter/Pasargad/Helper.php
+++ b/src/Adapter/Pasargad/Helper.php
@@ -1,7 +1,7 @@
 <?php
 namespace Tartan\Larapay\Adapter\Pasargad;
 
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 
 class Helper
 {

--- a/src/Adapter/PayIr/Helper.php
+++ b/src/Adapter/PayIr/Helper.php
@@ -1,7 +1,7 @@
 <?php
 namespace Tartan\Larapay\Adapter\PayIr;
 
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 
 class Helper
 {

--- a/src/Adapter/Payir.php
+++ b/src/Adapter/Payir.php
@@ -5,7 +5,7 @@ namespace Tartan\Larapay\Adapter;
 
 use Tartan\Larapay\Adapter\PayIr\Exception;
 use Tartan\Larapay\Adapter\PayIr\Helper;
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 
 /**
  * Class Payir

--- a/src/Adapter/Saman.php
+++ b/src/Adapter/Saman.php
@@ -7,7 +7,7 @@ namespace Tartan\Larapay\Adapter;
 use SoapClient;
 use SoapFault;
 use Tartan\Larapay\Adapter\Saman\Exception;
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 
 /**
  * Class Saman

--- a/src/Adapter/Zarinpal.php
+++ b/src/Adapter/Zarinpal.php
@@ -6,7 +6,7 @@ namespace Tartan\Larapay\Adapter;
 use SoapClient;
 use SoapFault;
 use Tartan\Larapay\Adapter\Zarinpal\Exception;
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 
 /**
  * Class Zarinpal

--- a/src/Adapter/Zibal.php
+++ b/src/Adapter/Zibal.php
@@ -5,7 +5,7 @@ namespace Tartan\Larapay\Adapter;
 
 use Tartan\Larapay\Adapter\Zibal\Exception;
 use Tartan\Larapay\Adapter\Zibal\Helper;
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 
 
 /**

--- a/src/Adapter/Zibal/Helper.php
+++ b/src/Adapter/Zibal/Helper.php
@@ -1,7 +1,7 @@
 <?php
 namespace Tartan\Larapay\Adapter\Zibal;
 
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 
 class Helper
 {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -9,7 +9,7 @@ use Tartan\Larapay\Exceptions\FailedTransactionException;
 use Tartan\Larapay\Exceptions\TransactionNotFoundException;
 use Tartan\Larapay\Models\LarapayTransaction;
 use Tartan\Larapay\Transaction\TransactionInterface;
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 use Exception;
 
 class Factory
@@ -38,7 +38,6 @@ class Factory
 
         XLog::debug('selected gateway [' . $adapter . ']');
         XLog::debug('available gateways', $readyToServerGateways);
-
         if (!in_array($adapter, $readyToServerGateways)) {
             throw new Exception(trans('larapay::larapay.gate_not_ready'));
         }

--- a/src/Models/Enum/Bank.php
+++ b/src/Models/Enum/Bank.php
@@ -12,7 +12,7 @@ class Bank
     const PASARGAD = 'Pasargad';
     const PAYIR = 'PayIr';
     const SADERAT = 'Saderat';
-    const ZARINPAL = 'Zarinpal';
+    const ZARINPAL = 'ZarinPal';
     const IDPAY = 'Idpay';
     const ZIBAL = 'Zibal';
     const NEXTPAY = 'Nextpay';

--- a/src/Models/LarapayTransaction.php
+++ b/src/Models/LarapayTransaction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Tartan\Larapay\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 use Tartan\Larapay\Exceptions\FailedReverseTransactionException;
 use Tartan\Larapay\Facades\Larapay;
 use Tartan\Larapay\Models\Traits\OnlineTransactionTrait;

--- a/src/Payable.php
+++ b/src/Payable.php
@@ -2,7 +2,7 @@
 
 namespace Tartan\Larapay;
 
-use Tartan\Log\Facades\XLog;
+use PhpMonsters\Log\Facades\XLog;
 use Tartan\Larapay\Contracts\LarapayTransaction as LarapayTransactionContract;
 use Tartan\Larapay\Exceptions\EmptyAmountException;
 use Tartan\Larapay\Facades\Larapay;


### PR DESCRIPTION
نام وقتی کوچک باشه داخل آرایه 
        $readyToServerGateways = explode(',', config('larapay.gateways'));

پیدا نمی شد در نتیجه باید اسمش کوچک باشه تا با خطا مواجه نشید