### PR TITLE
Resolve migration to read from config instead of env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ php artisan migrate
 ## Configuration
 If you complete installation step correctly, you can find Larapay config file as larapay.php in you project config file.
 
-For sandbox (banktest) you should set ```LARAPAY_MODE=development``` in your .env file otherwise set ```LARAPAY_MODE=production```
+For sandbox (banktest) you should set `LARAPAY_MODE=development` in your .env file otherwise set `LARAPAY_MODE=production`
 
-If you choose development mode, Larapay use banktest.ir as it's payment gateway.
+If you choose development mode, Larapay use banktest.ir as its payment gateway.
 
 Set your gateway(s) configs in your .env file. Here are some example:
 ```ini

--- a/config/larapay.php
+++ b/config/larapay.php
@@ -4,7 +4,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | PhpMonsters e-payment component`s operation mode
+    | PhpMonsters e-payment components operation mode
     |--------------------------------------------------------------------------
     |
     | *** very important config ***
@@ -198,11 +198,11 @@ return [
             ),
         ],
     ],
+
     /*
     |--------------------------------------------------------------------------
     | Route name for handle payment callback
     |--------------------------------------------------------------------------
     */
-
     'payment_callback' => env('LARAPAY_PAYMENT_CALLBACK' , '')
 ];

--- a/database/migrations/create_larapay_transaction_table.php.stub
+++ b/database/migrations/create_larapay_transaction_table.php.stub
@@ -10,7 +10,7 @@ class CreateLarapayTransactionTable extends Migration
     /**
      * Run the migrations.
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('larapay_transactions', function (Blueprint $table) {
             $table->increments('id');
@@ -58,7 +58,7 @@ class CreateLarapayTransactionTable extends Migration
     /**
      * Reverse the migrations.
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('larapay_transactions');
     }

--- a/database/migrations/create_larapay_transaction_table.php.stub
+++ b/database/migrations/create_larapay_transaction_table.php.stub
@@ -43,11 +43,10 @@ class CreateLarapayTransactionTable extends Migration
                 $table->jsonb('additional_data')->nullable()->default('{}');
                 $table->jsonb('sharing')->nullable()->default('{}');
             }
-            if (config('database.default') == 'mysql') {
-                $table->jsonb('extra_params')->nullable();
-                $table->jsonb('additional_data')->nullable();
-                $table->jsonb('sharing')->nullable();
-            }
+
+            $table->jsonb('extra_params')->nullable();
+            $table->jsonb('additional_data')->nullable();
+            $table->jsonb('sharing')->nullable();
 
             $table->dateTime('paid_at')->nullable();
             $table->timestamps();

--- a/database/migrations/create_larapay_transaction_table.php.stub
+++ b/database/migrations/create_larapay_transaction_table.php.stub
@@ -42,11 +42,11 @@ class CreateLarapayTransactionTable extends Migration
                 $table->jsonb('extra_params')->nullable()->default('{}');
                 $table->jsonb('additional_data')->nullable()->default('{}');
                 $table->jsonb('sharing')->nullable()->default('{}');
+            } else {
+                $table->jsonb('extra_params')->nullable();
+                $table->jsonb('additional_data')->nullable();
+                $table->jsonb('sharing')->nullable();
             }
-
-            $table->jsonb('extra_params')->nullable();
-            $table->jsonb('additional_data')->nullable();
-            $table->jsonb('sharing')->nullable();
 
             $table->dateTime('paid_at')->nullable();
             $table->timestamps();

--- a/database/migrations/create_larapay_transaction_table.php.stub
+++ b/database/migrations/create_larapay_transaction_table.php.stub
@@ -13,8 +13,6 @@ class CreateLarapayTransactionTable extends Migration
     public function up()
     {
         Schema::create('larapay_transactions', function (Blueprint $table) {
-
-            //primary key
             $table->increments('id');
 
             //morph to model like order or user
@@ -40,11 +38,12 @@ class CreateLarapayTransactionTable extends Migration
             $table->text('description')->nullable();
             $table->bigInteger('amount')->default(0);
 
-            if (env('DB_CONNECTION') == 'pgsql') { // for POSTGRESQL
+            if (config('database.default') == 'pgsql') {
                 $table->jsonb('extra_params')->nullable()->default('{}');
                 $table->jsonb('additional_data')->nullable()->default('{}');
                 $table->jsonb('sharing')->nullable()->default('{}');
-            } else { // for MYSQL
+            }
+            if (config('database.default') == 'mysql') {
                 $table->jsonb('extra_params')->nullable();
                 $table->jsonb('additional_data')->nullable();
                 $table->jsonb('sharing')->nullable();


### PR DESCRIPTION
Reason for this PR:

> For this reason, you should ensure you are only calling the env function from within your application's configuration (config) files. You can see many examples of this by examining Laravel's default configuration files. Configuration values may be accessed from anywhere in your application using the config function [described above](https://laravel.com/docs/12.x/configuration#accessing-configuration-values).

[Source](https://laravel.com/docs/12.x/configuration#configuration-caching)